### PR TITLE
Makefile changes to make building more robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,18 +7,24 @@ NAME = "hanalyzer"
 # List of target OS and architecture combinations
 TARGETS = \
     linux/amd64 \
-    linux/386 \
-    linux/arm \
     linux/arm64 \
     darwin/amd64 \
     darwin/arm64 \
     freebsd/amd64 \
-    freebsd/386 \
     windows/amd64 \
-    windows/386
+
+GO=go
+GO_MAJOR = $(shell $(GO) version | awk '{print $$3}' | cut -c 3- | cut -d '.' -f1)
+GO_MINOR = $(shell $(GO) version | awk '{print $$3}' | cut -c 3- | cut -d '.' -f2)
+MAJOR_SUPPORTED = 1
+MINOR_SUPPORTED = 23
+DEFAULT_TARGET = $(shell go version | awk '{print $$4}')
+
+all: has_minimum_go create_output_dir
+	$(MAKE) build/$(DEFAULT_TARGET)
 
 # Default target
-all: create_output_dir
+everything: has_minimum_go create_output_dir
 ifeq ($(target),)
 	$(foreach t,$(TARGETS),$(MAKE) build/$(t);)
 else
@@ -28,6 +34,14 @@ endif
 # Create output directory
 create_output_dir:
 	@mkdir -p $(OUTPUT_DIR)
+
+has_minimum_go:
+	@if [ $(GO_MAJOR) -gt $(MAJOR_SUPPORTED) ]; then \
+		exit 0; \
+	elif [ $(GO_MINOR) -lt $(MINOR_SUPPORTED) ]; then \
+		echo "Golang version is not supported. Please upgrade to at least $(MAJOR_SUPPORTED).$(MINOR_SUPPORTED)"; \
+		exit 1; \
+	fi
 
 # Build each target
 build/%: create_output_dir
@@ -50,12 +64,6 @@ clean:
 linux/amd64:
 	$(MAKE) build/linux/amd64
 
-linux/386:
-	$(MAKE) build/linux/386
-
-linux/arm:
-	$(MAKE) build/linux/arm
-
 linux/arm64:
 	$(MAKE) build/linux/arm64
 
@@ -68,11 +76,5 @@ darwin/arm64:
 freebsd/amd64:
 	$(MAKE) build/freebsd/amd64
 
-freebsd/386:
-	$(MAKE) build/freebsd/386
-
 windows/amd64:
 	$(MAKE) build/windows/amd64
-
-windows/386:
-	$(MAKE) build/windows/386


### PR DESCRIPTION
- removed useless 32-bit targets
- added go version check (minimum now set to 1.23)
- by default only build the current target
- added a target `make everything` that will cross-compile all other targets